### PR TITLE
Command_setadmin.java

### DIFF
--- a/src/me/unraveledmc/unraveledmcmod/command/Command_setadmin.java
+++ b/src/me/unraveledmc/unraveledmcmod/command/Command_setadmin.java
@@ -1,0 +1,197 @@
+package me.unraveledmc.unraveledmcmod.command;
+
+import java.util.Date;
+import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
+import me.unraveledmc.unraveledmcmod.admin.Admin;
+import me.unraveledmc.unraveledmcmod.command.CommandParameters;
+import me.unraveledmc.unraveledmcmod.command.CommandPermissions;
+import me.unraveledmc.unraveledmcmod.command.FreedomCommand;
+import me.unraveledmc.unraveledmcmod.command.SourceType;
+import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
+import me.unraveledmc.unraveledmcmod.player.FPlayer;
+import me.unraveledmc.unraveledmcmod.rank.Rank;
+import me.unraveledmc.unraveledmcmod.util.FUtil;
+import net.pravian.aero.util.Ips;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@CommandPermissions(level=Rank.SUPER_ADMIN, source=SourceType.BOTH)
+@CommandParameters(description="Adds, sets, and manages the admins in-game.", usage="/<command> <list | clean | reload | | setrank <username> <rank> | <add | remove | info> <username>>")
+public class Command_admin
+extends FreedomCommand {
+    @Override
+    public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
+    
+    {
+        checkRank(Rank.TELNET_ADMIN);
+        
+        
+        if (args.length < 1) {
+            return false;
+        }
+        Player player = getPlayer(args[0]);
+        switch (args[0]) {
+            case "list": {
+                this.msg("Superadmins: " + StringUtils.join(((UnraveledMCMod)this.plugin).al.getAdminNames(), (String)", "), ChatColor.GOLD);
+                return true;
+            }
+            case "clean": {
+                this.checkRank(Rank.TELNET_ADMIN);
+                FUtil.adminAction(sender.getName(), "Cleaning admin list", true);
+                ((UnraveledMCMod)this.plugin).al.deactivateOldEntries(true);
+                this.msg("Superadmins: " + StringUtils.join(((UnraveledMCMod)this.plugin).al.getAdminNames(), (String)", "), ChatColor.GOLD);
+                return true;
+            }
+            case "reload": {
+                this.checkRank(Rank.SUPER_ADMIN);
+                FUtil.adminAction(sender.getName(), "Reloading the admin list", true);
+                ((UnraveledMCMod)this.plugin).al.load();
+                this.msg("Admin list reloaded!");
+                return true;
+            }
+            case "setrank": {
+                this.checkRank(Rank.SENIOR_ADMIN);
+                if (args.length < 3) {
+                    return false;
+                }
+                Rank rank = Rank.findRank(args[2]);
+                if (rank == null) {
+                    this.msg("Unknown rank: " + rank);
+                    return true;
+                }
+                if (rank == Rank.SENIOR_ADMIN)
+                {
+                    msg("Unable to set to rank: " + rank);
+                    return false;
+                }
+                if (!rank.isAtLeast(Rank.SUPER_ADMIN)) {
+                    this.msg("Rank must be superadmin or higher.", ChatColor.RED);
+                    return true;
+                }
+                Admin admin = ((UnraveledMCMod)this.plugin).al.getEntryByName(args[1]);
+                if (admin == null) {
+                    this.msg("Unknown admin: " + args[1]);
+                    return true;
+                }
+                FUtil.adminAction(sender.getName(), "Setting " + admin.getName() + "'s rank to " + rank.getName(), true);
+                admin.setRank(rank);
+                ((UnraveledMCMod)this.plugin).al.save();
+                this.msg("Set " + admin.getName() + "'s rank to " + rank.getName());
+                return true;
+            }
+            
+            case "info": {
+                if (args.length < 2) {
+                    return false;
+                }
+                this.checkRank(Rank.SUPER_ADMIN);
+                Admin admin = ((UnraveledMCMod)this.plugin).al.getEntryByName(args[1]);
+                if (admin == null && (player = this.getPlayer(args[1])) != null) {
+                    admin = ((UnraveledMCMod)this.plugin).al.getAdmin(player);
+                }
+                if (admin == null) {
+                    this.msg("Superadmin not found: " + args[1]);
+                } else {
+                    this.msg(admin.toString());
+                }
+                return true;
+            }
+            case "add":
+            {
+                if (args.length < 2)
+                {
+                    return false;
+                }
+
+                checkRank(Rank.TELNET_ADMIN);
+
+            
+                if (player != null && plugin.al.isAdmin(player))
+                {
+                    msg("That player is already admin.");
+                    return true;
+                }
+
+                // Find the old admin entry
+                String name = player != null ? player.getName() : args[1];
+                Admin admin = null;
+                for (Admin loopAdmin : plugin.al.getAllAdmins().values())
+                {
+                    if (loopAdmin.getName().equalsIgnoreCase(name))
+                    {
+                        admin = loopAdmin;
+                        break;
+                    }
+                }
+
+                if (admin == null) // New admin
+                {
+                    if (player == null)
+                    {
+                        msg(FreedomCommand.PLAYER_NOT_FOUND);
+                        return true;
+                    }
+
+                    FUtil.adminAction(sender.getName(), "Adding " + player.getName() + " to the admin list", true);
+                    plugin.al.addAdmin(new Admin(player));
+                }
+                else // Existing admin
+                {
+                    FUtil.adminAction(sender.getName(), "Readding " + admin.getName() + " to the admin list", true);
+
+                    if (player != null)
+                    {
+                        admin.setName(player.getName());
+                        admin.addIp(Ips.getIp(player));
+                    }
+
+                    admin.setActive(true);
+                    admin.setLastLogin(new Date());
+
+                    plugin.al.save();
+                    plugin.al.updateTables();
+                }
+
+                if (player != null)
+                {
+                    final FPlayer fPlayer = plugin.pl.getPlayer(player);
+                    if (fPlayer.getFreezeData().isFrozen())
+                    {
+                        fPlayer.getFreezeData().setFrozen(false);
+                        msg(player.getPlayer(), "You have been unfrozen.");
+                    }
+                }
+
+                return true;
+            }
+             case "remove":
+            {
+                if (args.length < 2)
+                {
+                    return false;
+                }
+
+                checkRank(Rank.TELNET_ADMIN);
+                
+                Admin admin = player != null ? plugin.al.getAdmin(player) : plugin.al.getEntryByName(args[1]);
+
+                if (admin == null)
+                {
+                    msg("Superadmin not found - " + args[1]);
+                    return true;
+                }
+
+                FUtil.adminAction(sender.getName(), "Removing " + admin.getName() + " from the admin list", true);
+                admin.setActive(false);
+                plugin.al.save();
+                plugin.al.updateTables();
+                return true;
+            }
+      
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
So basically what the command will do, it will allow TELNET_ADMIN, SENIOR_ADMIN to set someone as admin in-game!

Obviously TELNET_ADMIN can only add someone to the admin list or remove them.
And SENIOR_ADMIN can do what a TELNET_ADMIN can, but with more permissions as
setrank, etc...

It's just like /saconfig but better and in-game feature. You can also execute the command in TELNET_CONSOLE / SENIOR_CONSOLE too!

(You can change rank names around)

- XGreenPlayz12