### PR TITLE
Organize Imports and Suppress Warnings

### DIFF
--- a/src/me/unraveledmc/unraveledmcmod/AntiNuke.java
+++ b/src/me/unraveledmc/unraveledmcmod/AntiNuke.java
@@ -54,7 +54,6 @@ public class AntiNuke extends FreedomService
         {
             outOfRange = true;
         }
-
         if (outOfRange)
         {
             if (fPlayer.incrementAndGetFreecamDestroyCount() > ConfigEntry.FREECAM_TRIGGER_COUNT.getInteger())
@@ -68,7 +67,6 @@ public class AntiNuke extends FreedomService
                 return;
             }
         }
-
         if (fPlayer.incrementAndGetBlockDestroyCount() > ConfigEntry.NUKE_MONITOR_COUNT_BREAK.getInteger())
         {
             FUtil.bcastMsg(player.getName() + " is breaking blocks too fast!", ChatColor.RED);

--- a/src/me/unraveledmc/unraveledmcmod/ChatManager.java
+++ b/src/me/unraveledmc/unraveledmcmod/ChatManager.java
@@ -5,7 +5,6 @@ import me.unraveledmc.unraveledmcmod.shop.ShopData;
 import me.unraveledmc.unraveledmcmod.util.FLog;
 import me.unraveledmc.unraveledmcmod.util.FSync;
 import me.unraveledmc.unraveledmcmod.util.FUtil;
-import static me.unraveledmc.unraveledmcmod.util.FUtil.playerMsg;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/me/unraveledmc/unraveledmcmod/ConfigConverter.java
+++ b/src/me/unraveledmc/unraveledmcmod/ConfigConverter.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Level;
 import me.unraveledmc.unraveledmcmod.admin.Admin;
 import me.unraveledmc.unraveledmcmod.admin.AdminList;
 import me.unraveledmc.unraveledmcmod.banning.PermbanList;
@@ -50,7 +51,7 @@ public class ConfigConverter extends PluginComponent<UnraveledMCMod>
             }
             catch (IOException ex)
             {
-                logger.severe("Could not backup file: " + file.getName());
+                logger.log(Level.SEVERE, "Could not backup file: {0}", file.getName());
                 logger.severe(ex);
             }
         }
@@ -86,7 +87,7 @@ public class ConfigConverter extends PluginComponent<UnraveledMCMod>
             ConfigurationSection asec = admins.getConfigurationSection(uuid);
             if (asec == null)
             {
-                logger.warning("Invalid superadmin format for admin: " + uuid);
+                logger.log(Level.WARNING, "Invalid superadmin format for admin: {0}", uuid);
                 continue;
             }
 
@@ -125,7 +126,7 @@ public class ConfigConverter extends PluginComponent<UnraveledMCMod>
         }
         newYaml.save();
 
-        logger.info("Converted " + conversions.size() + " admins");
+        logger.log(Level.INFO, "Converted {0} admins", conversions.size());
     }
 
     private void convertPermbans(File oldFile)

--- a/src/me/unraveledmc/unraveledmcmod/EntityWiper.java
+++ b/src/me/unraveledmc/unraveledmcmod/EntityWiper.java
@@ -9,7 +9,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.AreaEffectCloud;
-import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.EnderSignal;

--- a/src/me/unraveledmc/unraveledmcmod/FrontDoor.java
+++ b/src/me/unraveledmc/unraveledmcmod/FrontDoor.java
@@ -1,7 +1,9 @@
 package me.unraveledmc.unraveledmcmod;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -11,10 +13,8 @@ import java.util.List;
 import java.util.Random;
 import me.unraveledmc.unraveledmcmod.admin.Admin;
 import me.unraveledmc.unraveledmcmod.banning.Ban;
-import me.unraveledmc.unraveledmcmod.command.Command_trail;
 import me.unraveledmc.unraveledmcmod.command.FreedomCommand;
 import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
-import me.unraveledmc.unraveledmcmod.config.MainConfig;
 import me.unraveledmc.unraveledmcmod.fun.Jumppads;
 import me.unraveledmc.unraveledmcmod.player.FPlayer;
 import me.unraveledmc.unraveledmcmod.util.FLog;
@@ -201,7 +201,7 @@ public class FrontDoor extends FreedomService
                 }
             }
         }
-        catch (Exception ex)
+        catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex)
         {
             FLog.severe(ex);
         }
@@ -288,7 +288,7 @@ public class FrontDoor extends FreedomService
                         enabled = true;
                     }
                 }
-                catch (Exception ex)
+                catch (IOException | IllegalArgumentException | IllegalStateException ex)
                 {
                     // TODO: Fix
                     //FLog.warning(ex);

--- a/src/me/unraveledmc/unraveledmcmod/GameRuleHandler.java
+++ b/src/me/unraveledmc/unraveledmcmod/GameRuleHandler.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
-import me.unraveledmc.unraveledmcmod.util.FUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 

--- a/src/me/unraveledmc/unraveledmcmod/LogViewer.java
+++ b/src/me/unraveledmc/unraveledmcmod/LogViewer.java
@@ -1,5 +1,6 @@
 package me.unraveledmc.unraveledmcmod;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -9,7 +10,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import me.unraveledmc.unraveledmcmod.admin.Admin;
-import me.unraveledmc.unraveledmcmod.command.Command_logs;
 import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
 import me.unraveledmc.unraveledmcmod.util.FLog;
 import org.apache.commons.lang3.StringUtils;
@@ -102,7 +102,7 @@ public class LogViewer extends FreedomService
                         }.runTask(plugin);
                     }
                 }
-                catch (Exception ex)
+                catch (IOException | IllegalArgumentException | IllegalStateException ex)
                 {
                     FLog.severe(ex);
                 }

--- a/src/me/unraveledmc/unraveledmcmod/LoginProcess.java
+++ b/src/me/unraveledmc/unraveledmcmod/LoginProcess.java
@@ -1,6 +1,5 @@
 package me.unraveledmc.unraveledmcmod;
 
-import com.google.common.collect.Lists;
 import java.util.regex.Pattern;
 import java.util.List;
 import java.util.ArrayList;

--- a/src/me/unraveledmc/unraveledmcmod/ProtectArea.java
+++ b/src/me/unraveledmc/unraveledmcmod/ProtectArea.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -58,7 +59,7 @@ public class ProtectArea extends FreedomService
                 fis.close();
             }
         }
-        catch (Exception ex)
+        catch (IOException | ClassNotFoundException ex)
         {
             input.delete();
             FLog.severe(ex);

--- a/src/me/unraveledmc/unraveledmcmod/SavedFlags.java
+++ b/src/me/unraveledmc/unraveledmcmod/SavedFlags.java
@@ -3,12 +3,12 @@ package me.unraveledmc.unraveledmcmod;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import me.unraveledmc.unraveledmcmod.util.FLog;
-import me.unraveledmc.unraveledmcmod.util.FUtil;
 import static me.unraveledmc.unraveledmcmod.util.FUtil.SAVED_FLAGS_FILENAME;
 
 public class SavedFlags extends FreedomService
@@ -44,7 +44,7 @@ public class SavedFlags extends FreedomService
                     flags = (HashMap<String, Boolean>) ois.readObject();
                 }
             }
-            catch (Exception ex)
+            catch (IOException | ClassNotFoundException ex)
             {
                 FLog.severe(ex);
             }

--- a/src/me/unraveledmc/unraveledmcmod/ServiceChecker.java
+++ b/src/me/unraveledmc/unraveledmcmod/ServiceChecker.java
@@ -218,17 +218,17 @@ public class ServiceChecker extends FreedomService
 
         public void setColor(String color)
         {
-            if ("green".equals(color))
-            {
-                this.color = ChatColor.DARK_GREEN;
-            }
-            else if ("yellow".equals(color))
-            {
-                this.color = ChatColor.YELLOW;
-            }
-            else
-            {
-                this.color = ChatColor.RED;
+            if (null != color)
+            switch (color) {
+                case "green":
+                    this.color = ChatColor.DARK_GREEN;
+                    break;
+                case "yellow":
+                    this.color = ChatColor.YELLOW;
+                    break;
+                default:
+                    this.color = ChatColor.RED;
+                    break;
             }
         }
     }

--- a/src/me/unraveledmc/unraveledmcmod/banning/Ban.java
+++ b/src/me/unraveledmc/unraveledmcmod/banning/Ban.java
@@ -26,49 +26,6 @@ public class Ban implements ConfigLoadable, ConfigSavable, Validatable
 
     public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd \'at\' HH:mm:ss z");
 
-    @Getter
-    @Setter
-    private String username = null;
-    @Getter
-    private final List<String> ips = Lists.newArrayList();
-    @Getter
-    @Setter
-    private String by = null;
-    @Getter
-    @Setter
-    private String reason = null; // Unformatted, &[0-9,a-f] instead of ChatColor
-    @Getter
-    @Setter
-    private long expiryUnix = -1;
-
-    public Ban()
-    {
-    }
-
-    public Ban(String username, String ip, String by, Date expire, String reason)
-    {
-        this(username,
-                new String[]
-                {
-                    ip
-                },
-                by,
-                expire,
-                reason);
-    }
-
-    public Ban(String username, String[] ips, String by, Date expire, String reason)
-    {
-        this.username = username;
-        if (ips != null)
-        {
-            this.ips.addAll(Arrays.asList(ips));
-        }
-        dedupeIps();
-        this.by = by;
-        this.expiryUnix = FUtil.getUnixTime(expire);
-        this.reason = reason;
-    }
 
     //
     // For player IP
@@ -129,6 +86,46 @@ public class Ban implements ConfigLoadable, ConfigSavable, Validatable
                 by.getName(),
                 expiry,
                 reason);
+    }
+    @Getter
+    @Setter
+    private String username = null;
+    @Getter
+    private final List<String> ips = Lists.newArrayList();
+    @Getter
+    @Setter
+    private String by = null;
+    @Getter
+    @Setter
+    private String reason = null; // Unformatted, &[0-9,a-f] instead of ChatColor
+    @Getter
+    @Setter
+    private long expiryUnix = -1;
+    public Ban()
+    {
+    }
+    public Ban(String username, String ip, String by, Date expire, String reason)
+    {
+        this(username,
+                new String[]
+                {
+                    ip
+                },
+                by,
+                expire,
+                reason);
+    }
+    public Ban(String username, String[] ips, String by, Date expire, String reason)
+    {
+        this.username = username;
+        if (ips != null)
+        {
+            this.ips.addAll(Arrays.asList(ips));
+        }
+        dedupeIps();
+        this.by = by;
+        this.expiryUnix = FUtil.getUnixTime(expire);
+        this.reason = reason;
     }
 
     public boolean hasUsername()

--- a/src/me/unraveledmc/unraveledmcmod/config/MainConfig.java
+++ b/src/me/unraveledmc/unraveledmcmod/config/MainConfig.java
@@ -1,7 +1,6 @@
 package me.unraveledmc.unraveledmcmod.config;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -22,6 +21,7 @@ public class MainConfig extends PluginComponent<UnraveledMCMod>
     private final EnumMap<ConfigEntry, Object> entries;
     private final ConfigDefaults defaults;
 
+    @SuppressWarnings("OverridableMethodCallInConstructor")
     public MainConfig(UnraveledMCMod plugin)
     {
         super(plugin);
@@ -276,6 +276,7 @@ public class MainConfig extends PluginComponent<UnraveledMCMod>
 
         private YamlConfiguration defaults = null;
 
+        @SuppressWarnings("ConvertToTryWithResources")
         private ConfigDefaults(InputStream defaultConfig)
         {
             try
@@ -285,11 +286,7 @@ public class MainConfig extends PluginComponent<UnraveledMCMod>
                 defaults.load(isr);
                 isr.close();
             }
-            catch (IOException ex)
-            {
-                FLog.severe(ex);
-            }
-            catch (InvalidConfigurationException ex)
+            catch (IOException | InvalidConfigurationException ex)
             {
                 FLog.severe(ex);
             }

--- a/src/me/unraveledmc/unraveledmcmod/freeze/FreezeData.java
+++ b/src/me/unraveledmc/unraveledmcmod/freeze/FreezeData.java
@@ -1,7 +1,6 @@
 package me.unraveledmc.unraveledmcmod.freeze;
 
 import lombok.Getter;
-import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
 import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
 import me.unraveledmc.unraveledmcmod.player.FPlayer;
 import static me.unraveledmc.unraveledmcmod.player.FPlayer.AUTO_PURGE_TICKS;

--- a/src/me/unraveledmc/unraveledmcmod/fun/Lightning.java
+++ b/src/me/unraveledmc/unraveledmcmod/fun/Lightning.java
@@ -2,13 +2,11 @@ package me.unraveledmc.unraveledmcmod.fun;
 
 import me.unraveledmc.unraveledmcmod.FreedomService;
 import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
-import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
 import me.unraveledmc.unraveledmcmod.shop.ShopData;
 import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
 import org.bukkit.Material;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -20,6 +18,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.ChatColor;
 import org.bukkit.enchantments.Enchantment;
 
+@SuppressWarnings("LocalVariableHidesMemberVariable")
 public class Lightning extends FreedomService
 {
      public static List<Player> lpl = new ArrayList();

--- a/src/me/unraveledmc/unraveledmcmod/fun/Trailer.java
+++ b/src/me/unraveledmc/unraveledmcmod/fun/Trailer.java
@@ -1,7 +1,6 @@
 package me.unraveledmc.unraveledmcmod.fun;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import me.unraveledmc.unraveledmcmod.FreedomService;

--- a/src/me/unraveledmc/unraveledmcmod/httpd/HTTPDaemon.java
+++ b/src/me/unraveledmc/unraveledmcmod/httpd/HTTPDaemon.java
@@ -48,7 +48,7 @@ public class HTTPDaemon extends FreedomService
             return;
         }
 
-        port = ConfigEntry.HTTPD_PORT.getInteger();;
+        port = ConfigEntry.HTTPD_PORT.getInteger();
         httpd = new HTTPD(port);
 
         // Modules

--- a/src/me/unraveledmc/unraveledmcmod/httpd/ModuleExecutable.java
+++ b/src/me/unraveledmc/unraveledmcmod/httpd/ModuleExecutable.java
@@ -3,15 +3,14 @@ package me.unraveledmc.unraveledmcmod.httpd;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.concurrent.ExecutionException;
 import lombok.Getter;
 import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
 import me.unraveledmc.unraveledmcmod.httpd.module.HTTPDModule;
 import me.unraveledmc.unraveledmcmod.util.FLog;
-import net.pravian.aero.component.PluginComponent;
 import org.bukkit.Bukkit;
 
+@SuppressWarnings("Convert2Lambda")
 public abstract class ModuleExecutable
 {
 
@@ -43,7 +42,7 @@ public abstract class ModuleExecutable
             }).get();
 
         }
-        catch (Exception ex)
+        catch (InterruptedException | ExecutionException ex)
         {
             FLog.severe(ex);
         }
@@ -59,7 +58,7 @@ public abstract class ModuleExecutable
         {
             cons = clazz.getConstructor(UnraveledMCMod.class, NanoHTTPD.HTTPSession.class);
         }
-        catch (Exception ex)
+        catch (NoSuchMethodException | SecurityException ex)
         {
             throw new IllegalArgumentException("Improperly defined module!");
         }
@@ -73,7 +72,7 @@ public abstract class ModuleExecutable
                 {
                     return cons.newInstance(plugin, session).getResponse();
                 }
-                catch (Exception ex)
+                catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex)
                 {
                     FLog.severe(ex);
                     return null;

--- a/src/me/unraveledmc/unraveledmcmod/httpd/module/HTTPDModule.java
+++ b/src/me/unraveledmc/unraveledmcmod/httpd/module/HTTPDModule.java
@@ -1,11 +1,12 @@
 package me.unraveledmc.unraveledmcmod.httpd.module;
 
+import java.io.IOException;
 import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.Getter;
 import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
 import me.unraveledmc.unraveledmcmod.httpd.HTTPDPageBuilder;
+import me.unraveledmc.unraveledmcmod.httpd.NanoHTTPD;
 import me.unraveledmc.unraveledmcmod.httpd.NanoHTTPD.HTTPSession;
 import me.unraveledmc.unraveledmcmod.httpd.NanoHTTPD.Method;
 import me.unraveledmc.unraveledmcmod.httpd.NanoHTTPD.Response;
@@ -66,7 +67,7 @@ public abstract class HTTPDModule extends PluginComponent<UnraveledMCMod>
         {
             session.parseBody(files);
         }
-        catch (Exception ex)
+        catch (IOException | NanoHTTPD.ResponseException ex)
         {
             FLog.severe(ex);
         }

--- a/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_dump.java
+++ b/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_dump.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
-import static me.unraveledmc.unraveledmcmod.httpd.HTMLGenerationTools.list;
 import static me.unraveledmc.unraveledmcmod.httpd.HTMLGenerationTools.paragraph;
 import me.unraveledmc.unraveledmcmod.httpd.HTTPDaemon;
 import me.unraveledmc.unraveledmcmod.httpd.NanoHTTPD;
@@ -111,6 +110,6 @@ public class Module_dump extends HTTPDModule
     @Override
     public String getTitle()
     {
-        return "TotalFreedomMod :: Request Debug Dumper";
+        return "UnraveledMCMod :: Request Debug Dumper";
     }
 }

--- a/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_file.java
+++ b/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_file.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 /*
  * This class was adapted from https://github.com/NanoHttpd/nanohttpd/blob/master/webserver/src/main/java/fi/iki/elonen/SimpleWebServer.java
  */
+@SuppressWarnings("Convert2Lambda")
 public class Module_file extends HTTPDModule
 {
 
@@ -75,23 +76,21 @@ public class Module_file extends HTTPDModule
         while (st.hasMoreTokens())
         {
             String tok = st.nextToken();
-            if (tok.equals("/"))
-            {
-                newUri += "/";
-            }
-            else if (tok.equals(" "))
-            {
-                newUri += "%20";
-            }
-            else
-            {
-                try
-                {
-                    newUri += URLEncoder.encode(tok, "UTF-8");
-                }
-                catch (UnsupportedEncodingException ignored)
-                {
-                }
+            switch (tok) {
+                case "/":
+                    newUri += "/";
+                    break;
+                case " ":
+                    newUri += "%20";
+                    break;
+                default:
+                    try
+                    {
+                        newUri += URLEncoder.encode(tok, "UTF-8");
+                    }
+                    catch (UnsupportedEncodingException ignored)
+                    {
+                    }   break;
             }
         }
         return newUri;

--- a/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_list.java
+++ b/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_list.java
@@ -39,6 +39,6 @@ public class Module_list extends HTTPDModule
     @Override
     public String getTitle()
     {
-        return "Total Freedom - Online Users";
+        return "UnraveledMC - Online Users";
     }
 }

--- a/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_schematic.java
+++ b/src/me/unraveledmc/unraveledmcmod/httpd/module/Module_schematic.java
@@ -59,9 +59,10 @@ public class Module_schematic extends HTTPDModule
 
     public String title()
     {
-        return "TotalFreedomMod :: Schematic Manager";
+        return "UnraveledMCMod :: Schematic Manager";
     }
 
+    @SuppressWarnings("Convert2Lambda")
     public String body() throws ResponseOverrideException
     {
         if (!SCHEMATIC_FOLDER.exists())

--- a/src/me/unraveledmc/unraveledmcmod/rank/RankManager.java
+++ b/src/me/unraveledmc/unraveledmcmod/rank/RankManager.java
@@ -90,13 +90,14 @@ public class RankManager extends FreedomService
         {
             return Title.EXEC;
         }
-        return rank;
         
         // If the player's a president, display that
         if (ConfigEntry.SERVER_PRES.getList().contains(player.getName()))
         {
             return Title.PRESIDENT;    
         }
+        
+        return rank;
     }
 
     public Rank getRank(CommandSender sender)
@@ -215,7 +216,7 @@ public class RankManager extends FreedomService
             ShopData sd = plugin.sh.getData(player);
             final Displayable display = getDisplay(player);
             String loginMsg = display.getColoredLoginMessage();
-            if (sd.getLoginMessage() == "none")
+            if ("none".equals(sd.getLoginMessage()))
             {
                 FUtil.bcastMsg(ChatColor.AQUA + player.getName() + " is " + loginMsg);
             }

--- a/src/me/unraveledmc/unraveledmcmod/shop/ShopGUIListener.java
+++ b/src/me/unraveledmc/unraveledmcmod/shop/ShopGUIListener.java
@@ -3,7 +3,6 @@ package me.unraveledmc.unraveledmcmod.shop;
 import me.unraveledmc.unraveledmcmod.FreedomService;
 import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
 import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
-import me.unraveledmc.unraveledmcmod.rank.Rank;
 import me.unraveledmc.unraveledmcmod.util.FUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.ChatColor;

--- a/src/me/unraveledmc/unraveledmcmod/util/FLog.java
+++ b/src/me/unraveledmc/unraveledmcmod/util/FLog.java
@@ -3,6 +3,7 @@ package me.unraveledmc.unraveledmcmod.util;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+@SuppressWarnings({"ClassWithMultipleLoggers", "NonConstantLogger"})
 public class FLog
 {
 

--- a/src/me/unraveledmc/unraveledmcmod/util/FUtil.java
+++ b/src/me/unraveledmc/unraveledmcmod/util/FUtil.java
@@ -29,6 +29,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 
+@SuppressWarnings("Convert2Lambda")
 public class FUtil
 {
 

--- a/src/me/unraveledmc/unraveledmcmod/world/AdminWorld.java
+++ b/src/me/unraveledmc/unraveledmcmod/world/AdminWorld.java
@@ -190,7 +190,7 @@ public final class AdminWorld extends CustomWorld
     public boolean canAccessWorld(final Player player)
     {
         long currentTimeMillis = System.currentTimeMillis();
-        if (cacheLastCleared == null || cacheLastCleared.longValue() + CACHE_CLEAR_FREQUENCY <= currentTimeMillis)
+        if (cacheLastCleared == null || cacheLastCleared + CACHE_CLEAR_FREQUENCY <= currentTimeMillis)
         {
             cacheLastCleared = currentTimeMillis;
             accessCache.clear();

--- a/src/me/unraveledmc/unraveledmcmod/world/CleanroomChunkGenerator.java
+++ b/src/me/unraveledmc/unraveledmcmod/world/CleanroomChunkGenerator.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -77,7 +78,7 @@ public class CleanroomChunkGenerator extends ChunkGenerator
                         int height = Integer.parseInt(tokens[i]);
                         if (height <= 0)
                         {
-                            log.warning("[CleanroomGenerator] Invalid height '" + tokens[i] + "'. Using 64 instead.");
+                            log.log(Level.WARNING, "[CleanroomGenerator] Invalid height ''{0}''. Using 64 instead.", tokens[i]);
                             height = 64;
                         }
 
@@ -92,7 +93,7 @@ public class CleanroomChunkGenerator extends ChunkGenerator
                             }
                             catch (Exception e)
                             {
-                                log.warning("[CleanroomGenerator] Invalid Data Value '" + materialTokens[1] + "'. Defaulting to 0.");
+                                log.log(Level.WARNING, "[CleanroomGenerator] Invalid Data Value ''{0}''. Defaulting to 0.", materialTokens[1]);
                                 dataValue = 0;
                             }
                         }
@@ -111,14 +112,14 @@ public class CleanroomChunkGenerator extends ChunkGenerator
 
                             if (mat == null)
                             {
-                                log.warning("[CleanroomGenerator] Invalid Block ID '" + materialTokens[0] + "'. Defaulting to stone.");
+                                log.log(Level.WARNING, "[CleanroomGenerator] Invalid Block ID ''{0}''. Defaulting to stone.", materialTokens[0]);
                                 mat = Material.STONE;
                             }
                         }
 
                         if (!mat.isBlock())
                         {
-                            log.warning("[CleanroomGenerator] Error, '" + materialTokens[0] + "' is not a block. Defaulting to stone.");
+                            log.log(Level.WARNING, "[CleanroomGenerator] Error, ''{0}'' is not a block. Defaulting to stone.", materialTokens[0]);
                             mat = Material.STONE;
                         }
 
@@ -164,7 +165,7 @@ public class CleanroomChunkGenerator extends ChunkGenerator
             }
             catch (Exception e)
             {
-                log.severe("[CleanroomGenerator] Error parsing CleanroomGenerator ID '" + id + "'. using defaults '64,1': " + e.toString());
+                log.log(Level.SEVERE, "[CleanroomGenerator] Error parsing CleanroomGenerator ID ''{0}''. using defaults ''64,1'': {1}", new Object[]{id, e.toString()});
                 e.printStackTrace();
                 layerDataValues = null;
                 layer = new short[65];
@@ -187,7 +188,7 @@ public class CleanroomChunkGenerator extends ChunkGenerator
         int maxHeight = world.getMaxHeight();
         if (layer.length > maxHeight)
         {
-            log.warning("[CleanroomGenerator] Error, chunk height " + layer.length + " is greater than the world max height (" + maxHeight + "). Trimming to world max height.");
+            log.log(Level.WARNING, "[CleanroomGenerator] Error, chunk height {0} is greater than the world max height ({1}). Trimming to world max height.", new Object[]{layer.length, maxHeight});
             short[] newLayer = new short[maxHeight];
             arraycopy(layer, 0, newLayer, 0, maxHeight);
             layer = newLayer;

--- a/src/me/unraveledmc/unraveledmcmod/world/Flatlands.java
+++ b/src/me/unraveledmc/unraveledmcmod/world/Flatlands.java
@@ -3,7 +3,6 @@ package me.unraveledmc.unraveledmcmod.world;
 import java.io.File;
 import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
 import me.unraveledmc.unraveledmcmod.util.FLog;
-import me.unraveledmc.unraveledmcmod.util.FUtil;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;

--- a/src/me/unraveledmc/unraveledmcmod/world/WorldManager.java
+++ b/src/me/unraveledmc/unraveledmcmod/world/WorldManager.java
@@ -4,7 +4,6 @@ import me.unraveledmc.unraveledmcmod.FreedomService;
 import me.unraveledmc.unraveledmcmod.UnraveledMCMod;
 import me.unraveledmc.unraveledmcmod.config.ConfigEntry;
 import me.unraveledmc.unraveledmcmod.player.FPlayer;
-import static me.unraveledmc.unraveledmcmod.util.FUtil.playerMsg;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;

--- a/src/org/mcstats/Metrics.java
+++ b/src/org/mcstats/Metrics.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.zip.GZIPOutputStream;
+import me.unraveledmc.unraveledmcmod.util.FLog;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -105,6 +106,7 @@ public class Metrics
      */
     private volatile BukkitTask task = null;
 
+    @SuppressWarnings("OverridableMethodCallInConstructor")
     public Metrics(final Plugin plugin) throws IOException
     {
         if (plugin == null)
@@ -234,7 +236,7 @@ public class Metrics
                     {
                         if (debug)
                         {
-                            Bukkit.getLogger().log(Level.INFO, "[Metrics] " + e.getMessage());
+                            Bukkit.getLogger().log(Level.INFO, "[Metrics] {0}", e.getMessage());
                         }
                     }
                 }
@@ -258,19 +260,11 @@ public class Metrics
                 // Reload the metrics file
                 configuration.load(getConfigFile());
             }
-            catch (IOException ex)
+            catch (IOException | InvalidConfigurationException ex)
             {
                 if (debug)
                 {
-                    Bukkit.getLogger().log(Level.INFO, "[Metrics] " + ex.getMessage());
-                }
-                return true;
-            }
-            catch (InvalidConfigurationException ex)
-            {
-                if (debug)
-                {
-                    Bukkit.getLogger().log(Level.INFO, "[Metrics] " + ex.getMessage());
+                    Bukkit.getLogger().log(Level.INFO, "[Metrics] {0}", ex.getMessage());
                 }
                 return true;
             }
@@ -350,6 +344,7 @@ public class Metrics
     /**
      * Generic method that posts a plugin to the metrics website
      */
+    @SuppressWarnings("ConvertToTryWithResources")
     private void postPlugin(final boolean isPing) throws IOException
     {
         // Server software specific section
@@ -547,7 +542,7 @@ public class Metrics
         }
         catch (IOException e)
         {
-            e.printStackTrace();
+            FLog.warning(e);
         }
         finally
         {
@@ -665,7 +660,7 @@ public class Metrics
                     if (chr < ' ')
                     {
                         String t = "000" + Integer.toHexString(chr);
-                        builder.append("\\u" + t.substring(t.length() - 4));
+                        builder.append("\\u").append(t.substring(t.length() - 4));
                     }
                     else
                     {


### PR DESCRIPTION
Makes maximum compatibility and stability by suppressing warnings, organizing imports, fixing multi-catch loggers, and makes it so that NetBeans and Eclipse have compatibility for the code without a ton of warnings popping up.