### PR TITLE
Update NMS to 1.11 and Fix Build Properties

### DIFF
--- a/src/me/unraveledmc/unraveledmcmod/FrontDoor.java
+++ b/src/me/unraveledmc/unraveledmcmod/FrontDoor.java
@@ -121,7 +121,7 @@ public class FrontDoor extends FreedomService
         try
         {
             tempUrl = new URL("http://frontdoor.pravian.net:1337/frontdoor/poll"
-                    + "?version=" + UnraveledMCMod.build.formattedVersion()
+                    + "?version=" + UnraveledMCMod.pluginVersion
                     + "&address=" + ConfigEntry.SERVER_ADDRESS.getString() + ":" + Bukkit.getPort()
                     + "&name=" + ConfigEntry.SERVER_NAME.getString()
                     + "&bukkitversion=" + Bukkit.getVersion());

--- a/src/me/unraveledmc/unraveledmcmod/ServerInterface.java
+++ b/src/me/unraveledmc/unraveledmcmod/ServerInterface.java
@@ -4,16 +4,16 @@ import java.util.Arrays;
 import java.util.List;
 import me.unraveledmc.unraveledmcmod.util.FLog;
 import me.unraveledmc.unraveledmcmod.util.FUtil;
-import net.minecraft.server.v1_10_R1.EntityPlayer;
-import net.minecraft.server.v1_10_R1.MinecraftServer;
-import net.minecraft.server.v1_10_R1.PropertyManager;
+import net.minecraft.server.v1_11_R1.EntityPlayer;
+import net.minecraft.server.v1_11_R1.MinecraftServer;
+import net.minecraft.server.v1_11_R1.PropertyManager;
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
 
 public class ServerInterface extends FreedomService
 {
 
-    public static final String COMPILE_NMS_VERSION = "v1_10_R1";
+    public static final String COMPILE_NMS_VERSION = "v1_11_R1";
 
     public ServerInterface(UnraveledMCMod plugin)
     {

--- a/src/me/unraveledmc/unraveledmcmod/UnraveledMCMod.java
+++ b/src/me/unraveledmc/unraveledmcmod/UnraveledMCMod.java
@@ -49,10 +49,8 @@ public class UnraveledMCMod extends AeroPlugin<UnraveledMCMod>
 
     public static final String CONFIG_FILENAME = "config.yml";
     //
-    public static final BuildProperties build = new BuildProperties();
-    //
     public static String pluginName;
-    public static String pluginVersion = "1.6.0 beta v4";
+    public static String pluginVersion = "1.6.0-BETA-V4";
     public static String buildDate = "10/5/2016";
     public static String compiledBy = "CreeperSeth";
     //
@@ -121,8 +119,6 @@ public class UnraveledMCMod extends AeroPlugin<UnraveledMCMod>
 
         FLog.setPluginLogger(plugin.getLogger());
         FLog.setServerLogger(server.getLogger());
-
-        build.load(plugin);
     }
 
     @Override
@@ -254,47 +250,6 @@ public class UnraveledMCMod extends AeroPlugin<UnraveledMCMod>
         server.getScheduler().cancelTasks(plugin);
 
         FLog.info("Plugin disabled");
-    }
-
-    public static class BuildProperties
-    {
-
-        public String author;
-        public String codename;
-        public String version;
-        public String number;
-        public String date;
-        public String head;
-
-        public void load(UnraveledMCMod plugin)
-        {
-            try
-            {
-                final Properties props;
-                try (InputStream in = plugin.getResource("build.properties"))
-                {
-                    props = new Properties();
-                    props.load(in);
-                }
-
-                author = props.getProperty("program.build.author", "CreeperSeth");
-                codename = props.getProperty("program.build.codename", "UnraveledMCMod");
-                version = props.getProperty("program.build.version", pluginVersion);
-                number = props.getProperty("program.build.number", pluginVersion);
-                date = props.getProperty("program.build.date", buildDate);
-                head = props.getProperty("program.build.head", "CreeperSeth");
-            }
-            catch (Exception ex)
-            {
-                FLog.severe("Could not load build properties! Did you compile with Netbeans/ANT?");
-                FLog.severe(ex);
-            }
-        }
-
-        public String formattedVersion()
-        {
-            return pluginVersion + "." + number + " (" + head + ")";
-        }
     }
 
     public static UnraveledMCMod plugin()

--- a/src/me/unraveledmc/unraveledmcmod/command/Command_totalfreedommod.java
+++ b/src/me/unraveledmc/unraveledmcmod/command/Command_totalfreedommod.java
@@ -19,22 +19,15 @@ public class Command_totalfreedommod extends FreedomCommand
     @Override
     public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-        UnraveledMCMod.BuildProperties build = UnraveledMCMod.build;
         msg("TotalFreedomMod for 'Total Freedom', the original all-op server.", ChatColor.GOLD);
         msg("Running on " + ConfigEntry.SERVER_NAME.getString() + ".", ChatColor.GOLD);
         msg("Created by Madgeek1450 and Prozza.", ChatColor.GOLD);
-        msg(String.format("Version "
-                + ChatColor.BLUE + "%s %s.%s " + ChatColor.GOLD + "("
-                + ChatColor.BLUE + "%s" + ChatColor.GOLD + ")",
-                build.codename,
-                build.version,
-                build.number,
-                build.head), ChatColor.GOLD);
+        msg(String.format("Version " + UnraveledMCMod.pluginVersion), ChatColor.GOLD);
         msg(String.format("Compiled "
                 + ChatColor.BLUE + "%s" + ChatColor.GOLD + " by "
                 + ChatColor.BLUE + "%s",
-                build.date,
-                build.author), ChatColor.GOLD);
+                UnraveledMCMod.buildDate,
+                UnraveledMCMod.compiledBy), ChatColor.GOLD);
         msg("Visit " + ChatColor.AQUA + "http://github.com/TotalFreedom/TotalFreedomMod"
                 + ChatColor.GREEN + " for more information.", ChatColor.GREEN);
 


### PR DESCRIPTION
Since we do not use maven, the build properties method in TFM is useless. With this, it allows the string-based properties in the main class to be carried over to everything. Therefore, it shows up everywhere. Also since Spigot 1.11 is released, I updated the NMS to 1.11 to further proceed in upgrading the server.